### PR TITLE
Update allowlist to allow Sentry for Monzo

### DIFF
--- a/easylist_cookie/easylist_cookie_general_hide.txt
+++ b/easylist_cookie/easylist_cookie_general_hide.txt
@@ -12049,6 +12049,7 @@
 ##.ucgCookieBar
 ##.ucn-block
 ##.ud-component--eu-cookie-message--app
+##.ud-component--footer--eu-cookie-message
 ##.ue-c-site-message--cookies
 ##.ueltje-cookie-accept
 ##.ug3-cookie-info-container

--- a/easyprivacy/easyprivacy_allowlist.txt
+++ b/easyprivacy/easyprivacy_allowlist.txt
@@ -190,6 +190,7 @@
 @@||jbj.co.uk^*/analytics.js$script,~third-party
 @@||js-agent.newrelic.com/nr-spa-$script,domain=kapwing.com
 @@||js.sentry-cdn.com^$script,domain=book.dmm.com|jobs.ch
+@@||js.sentry-cdn.com^$script,domain=verify.monzo.com
 @@||jsrdn.com/s/$script,domain=distro.tv
 @@||jwpcdn.com/player/plugins/googima/*/googima.js$script,domain=ladbible.com
 @@||kawasaki.com/Scripts/Analytics/BaseAnalytics.js$script,~third-party


### PR DESCRIPTION
The Monzo (https://monzo.com/) payment verification process is broken by the widescale blocking of sentry (introduced in d610e11c83aa6657a4657156d76b93cee4f19579), because it uses sentry to send events to the payment page once the user has verified payment in their app. 

With the block in place, the user will approve the payment in the Monzo app, but the merchants page will never update (you can force it by right clicking on the frame and choosing reload).

More discussion can be found on Twitter here - https://twitter.com/bentasker/status/1420354891453763588